### PR TITLE
Add "Notify on every message" account preference

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -635,6 +635,9 @@
     <!-- On Settings screen, section heading -->
     <string name="account_settings_servers">Server settings</string>
 
+    <!-- On Settings screen, notify on every message pop-up menu label -->
+    <string name="account_settings_notify_every_message_label">Notify for every message</string>
+
     <!-- Mailbox settings activity title [CHAR LIMIT=none] -->
     <string name="mailbox_settings_activity_title">Sync options</string>
     <!-- Mailbox settings activity title, with the target folder name [CHAR LIMIT=none] -->

--- a/res/xml/account_settings_preferences.xml
+++ b/res/xml/account_settings_preferences.xml
@@ -106,6 +106,12 @@
             android:defaultValue="false"
             android:title="@string/account_settings_vibrate_when_label" />
 
+        <CheckBoxPreference
+            android:key="notification-notify-every-message"
+            android:dependency="notifications-enabled"
+            android:defaultValue="false"
+            android:title="@string/account_settings_notify_every_message_label" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/src/com/android/email/activity/setup/AccountSettingsFragment.java
+++ b/src/com/android/email/activity/setup/AccountSettingsFragment.java
@@ -119,6 +119,7 @@ public class AccountSettingsFragment extends PreferenceFragment
     private CheckBoxPreference mAccountBackgroundAttachments;
     private CheckBoxPreference mInboxNotify;
     private CheckBoxPreference mInboxVibrate;
+    private CheckBoxPreference mInboxNotifyEveryMessage;
     private Preference mInboxRingtone;
     private PreferenceCategory mNotificationsCategory;
     private CheckBoxPreference mSyncContacts;
@@ -388,6 +389,12 @@ public class AccountSettingsFragment extends PreferenceFragment
             mInboxFolderPreferences.setNotificationVibrateEnabled(vibrateSetting);
             preferenceChanged(FolderPreferences.PreferenceKeys.NOTIFICATION_VIBRATE, newValue);
             return true;
+        } else if (FolderPreferences.PreferenceKeys.NOTIFICATION_NOTIFY_EVERY_MESSAGE.equals(key)) {
+            final boolean notifyEveryMessageSetting = (Boolean) newValue;
+            mInboxNotifyEveryMessage.setChecked(notifyEveryMessageSetting);
+            mInboxFolderPreferences.setEveryMessageNotificationEnabled(notifyEveryMessageSetting);
+            preferenceChanged(FolderPreferences.PreferenceKeys.NOTIFICATION_NOTIFY_EVERY_MESSAGE, newValue);
+            return true;
         } else if (FolderPreferences.PreferenceKeys.NOTIFICATIONS_ENABLED.equals(key)) {
             mInboxFolderPreferences.setNotificationsEnabled((Boolean) newValue);
             preferenceChanged(FolderPreferences.PreferenceKeys.NOTIFICATIONS_ENABLED, newValue);
@@ -602,6 +609,8 @@ public class AccountSettingsFragment extends PreferenceFragment
                                     mInboxFolderPreferences.areNotificationsEnabled());
                             mInboxVibrate.setChecked(
                                     mInboxFolderPreferences.isNotificationVibrateEnabled());
+                            mInboxNotifyEveryMessage.setChecked(
+                                    mInboxFolderPreferences.isEveryMessageNotificationEnabled());
                             setRingtoneSummary();
                             // Notification preferences must be disabled until after
                             // mInboxFolderPreferences is available, so enable them here.
@@ -794,6 +803,10 @@ public class AccountSettingsFragment extends PreferenceFragment
             // No vibrator present. Remove the preference altogether.
             mNotificationsCategory.removePreference(mInboxVibrate);
         }
+
+        mInboxNotifyEveryMessage = (CheckBoxPreference) findPreference(
+                FolderPreferences.PreferenceKeys.NOTIFICATION_NOTIFY_EVERY_MESSAGE);
+        mInboxNotifyEveryMessage.setOnPreferenceChangeListener(this);
 
         final Preference retryAccount = findPreference(PREFERENCE_POLICIES_RETRY_ACCOUNT);
         final PreferenceCategory policiesCategory = (PreferenceCategory) findPreference(

--- a/src/com/android/email/preferences/EmailPreferenceMigrator.java
+++ b/src/com/android/email/preferences/EmailPreferenceMigrator.java
@@ -161,6 +161,7 @@ public class EmailPreferenceMigrator extends BasePreferenceMigrator {
                         & com.android.emailcommon.provider.Account.FLAGS_VIBRATE) != 0;
                 folderPreferences.setNotificationVibrateEnabled(vibrate);
 
+                folderPreferences.setEveryMessageNotificationEnabled(true);
                 folderPreferences.commit();
             }
         }


### PR DESCRIPTION
The new UnifiedEmail preferences have the new option to notify on every email message (which defaults to false if not set). Since this option in Email app, there is no way to enable "proper" (until this change) email notifications.
This PR implements this setting.

*Please note that this is my first attempt with Android in general, don't yell if something vital is missing or is wrong :-)
