### PR TITLE
Fix NPE in getHierarchicalFolder

### DIFF
--- a/src/com/android/email/activity/setup/MailboxSettings.java
+++ b/src/com/android/email/activity/setup/MailboxSettings.java
@@ -374,7 +374,9 @@ public class MailboxSettings extends PreferenceActivity {
             Folder tmp = folder;
             while (tmp != null && tmp.parent != null && !tmp.parent.toString().isEmpty()) {
                 tmp = folders.get(tmp.parent);
-                name = tmp.name + "/" + name;
+                if (tmp != null) {
+                    name = tmp.name + "/" + name;
+                }
             }
             return name;
         }


### PR DESCRIPTION
Fixes exceptions like this:
java.lang.NullPointerException: Attempt to read from field 'java.lang.String com.android.mail.providers.Folder.name' on a null object reference
at com.android.email.activity.setup.MailboxSettings$MailboxSettingsFolderLoaderCallbacks.getHierarchicalFolder(MailboxSettings.java:377)
